### PR TITLE
fixed chdir directive templating for php-fpm pool object

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ php_packages: "{{ set(php_packages + ['php' + php_version + '-fpm']) }}"
 
 php_fpm_enabled: no
 php_fpm_pool_uid_gid: 1000
+php_fpm_www_dir: /var/www

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,5 +19,5 @@ galaxy_info:
 dependencies:
 - src: git@github.com:blunix/role-php.git
   name: blunix.role-php
-  version: 1.0.6
+  version: 1.0.7
   scm: git

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 - src: git@github.com:blunix/role-php.git
   name: blunix.role-php
-  version: 1.0.6
+  version: 1.0.7
   scm: git

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -9,7 +9,7 @@ lint:
   name: yamllint
 platforms:
   - name: stretch
-    box: bento/debian-9.0
+    box: bento/debian-9
   - name: xenial
     box: bento/ubuntu-16.04
 provisioner:

--- a/molecule/install/playbook.yml
+++ b/molecule/install/playbook.yml
@@ -122,7 +122,7 @@
             <?php
             phpinfo();
             ?>
-        dest: "/var/www/www_ejemplo_es/app/htdocs/info.php"
+        dest: "/srv/www/www_ejemplo_es/app/htdocs/info.php"
         owner: www-data
         group: www-data
         mode: 0640

--- a/molecule/install/playbook.yml
+++ b/molecule/install/playbook.yml
@@ -32,7 +32,10 @@
     - role: role-php-fpm
       # the name will be used to abstract the username, group name, logfile name (TODO should also be syslog prefix), tmpdir path
       php_fpm_pool_name: www_example_com
-      # the home dir for the user will be /var/www/{{ php_fpm_pool_name }}/
+      # The php-fpm www dir, such as /var/www, below which the php_fpm_pool_dir will be created as the users home directory
+      # default: /var/www
+      php_fpm_www_dir: /var/www
+      # the home dir for the user will be {{ php_fpm_www_dir }}/{{ php_fpm_pool_name }}/
       # append a custom path for a different chdir - default: omitted
       php_fpm_pool_chdir: htdocs
       # User and group ID for new user - default 1000
@@ -82,7 +85,8 @@
       # if user and group is not set, a user called php_fpm_pool_name will be created
       php_fpm_pool_user: www-data
       php_fpm_pool_group: www-data
-      php_fpm_pool_chdir: htdocs
+      php_fpm_www_dir: /srv/www
+      php_fpm_pool_chdir: app/htdocs
       # if user and group are set to 'www-data', always use 33!
       php_fpm_pool_uid_gid: 33
       php_fpm_pool_tmpdir_tmpfs_size: 128
@@ -118,7 +122,7 @@
             <?php
             phpinfo();
             ?>
-        dest: "/var/www/www_ejemplo_es/htdocs/info.php"
+        dest: "/var/www/www_ejemplo_es/app/htdocs/info.php"
         owner: www-data
         group: www-data
         mode: 0640

--- a/molecule/install/requirements.yml
+++ b/molecule/install/requirements.yml
@@ -1,4 +1,4 @@
 - src: git@github.com:blunix/role-php.git
   name: blunix.role-php
-  version: 1.0.6
+  version: 1.0.7
   scm: git

--- a/molecule/install/tests/test_php_fpm_worker_count.py
+++ b/molecule/install/tests/test_php_fpm_worker_count.py
@@ -13,7 +13,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 # this excludes the grep process from the process list output
 @pytest.mark.parametrize("domain,worker_count", [
     ["www_example_com", 3],
-    ["www_beispiel_de", 2]
+    ["www_beispiel_de", 2],
+    ["www_ejemplo_es", 2]
 ])
 # pythons psutil does not return the full process name (only "php-fpm7.1", not "php-fpm: pool www_beispiel_de") hence I use "ps aux"  # noqa: E501
 def test_php_info_variable(host, domain, worker_count):

--- a/molecule/install/tests/test_php_info_variable.py
+++ b/molecule/install/tests/test_php_info_variable.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def run_helper_script(path, domain):
+def run_helper_script(host, path, domain):
     helper_script = """SCRIPT_FILENAME={} \
     REQUEST_METHOD=GET \
     cgi-fcgi -bind -connect /var/run/php/{}.sock
@@ -19,13 +19,13 @@ def run_helper_script(path, domain):
 
 @pytest.mark.parametrize("domain,variable,value,path", [
     ["www_example_com", "memory_limit", "256M", "/var/www/www_example_com/htdocs/info.php"],
-    ["www_beispiel_de", "memory_limit", "128M", "/var/www/www_example_com/htdocs/info.php"],
+    ["www_beispiel_de", "memory_limit", "128M", "/var/www/www_beispiel_de/htdocs/info.php"],
     ["www_beispiel_de", "upload_max_filesize", "128M", "/var/www/www_beispiel_de/htdocs/info.php"],
     ["www_beispiel_de", "date.timezone", "Europe/Berlin", "/var/www/www_beispiel_de/htdocs/info.php"],
     ["www_ejemplo_es", "date.timezone", "Europe/Berlin", "/srv/www/www_ejemplo_es/app/htdocs/info.php"],
 ])
 def test_php_info_variable(host, domain, variable, value, path):
-    stdout = run_helper_script(path, domain)
+    stdout = run_helper_script(host, path, domain)
     found_variable = False
     found_value = False
     for line in stdout.split('\r\n'):

--- a/molecule/install/tests/test_php_info_variable.py
+++ b/molecule/install/tests/test_php_info_variable.py
@@ -8,24 +8,24 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def run_helper_script(host, domain):
-    helper_script = """SCRIPT_FILENAME=/var/www/{}/htdocs/info.php \
+def run_helper_script(path, domain):
+    helper_script = """SCRIPT_FILENAME={} \
     REQUEST_METHOD=GET \
     cgi-fcgi -bind -connect /var/run/php/{}.sock
-    """.format(domain, domain)
+    """.format(path, domain)
     stdout = host.run(helper_script).stdout
     return stdout
 
 
-@pytest.mark.parametrize("domain,variable,value", [
-    ["www_example_com", "memory_limit", "256M"],
-    ["www_beispiel_de", "memory_limit", "128M"],
-    ["www_beispiel_de", "upload_max_filesize", "128M"],
-    ["www_beispiel_de", "date.timezone", "Europe/Berlin"],
-    ["www_ejemplo_es", "date.timezone", "Europe/Berlin"],
+@pytest.mark.parametrize("domain,variable,value,path", [
+    ["www_example_com", "memory_limit", "256M", "/var/www/www_example_com/htdocs/info.php"],
+    ["www_beispiel_de", "memory_limit", "128M", "/var/www/www_example_com/htdocs/info.php"],
+    ["www_beispiel_de", "upload_max_filesize", "128M", "/var/www/www_beispiel_de/htdocs/info.php"],
+    ["www_beispiel_de", "date.timezone", "Europe/Berlin", "/var/www/www_beispiel_de/htdocs/info.php"],
+    ["www_ejemplo_es", "date.timezone", "Europe/Berlin", "/srv/www/www_ejemplo_es/app/htdocs/info.php"],
 ])
-def test_php_info_variable(host, domain, variable, value):
-    stdout = run_helper_script(host, domain)
+def test_php_info_variable(host, domain, variable, value, path):
+    stdout = run_helper_script(path, domain)
     found_variable = False
     found_value = False
     for line in stdout.split('\r\n'):

--- a/tasks/configure/default.yml
+++ b/tasks/configure/default.yml
@@ -66,7 +66,7 @@
     owner: "{{ php_fpm_pool_user | default(php_fpm_pool_name) }}"
     group: "{{ php_fpm_pool_group | default(php_fpm_pool_name) }}"
     mode: 0750
-  when: php_fpm_pool_chdir is defined and stat_php_fpm_chdir_symlink.stat.islnk is defined
+  when: php_fpm_pool_chdir is defined and stat_php_fpm_chdir_symlink.stat.islnk is not defined
 
 - name: create main tmpdir for all php-fpm pools of this php_version
   file:

--- a/tasks/configure/default.yml
+++ b/tasks/configure/default.yml
@@ -34,6 +34,8 @@
     system: true
     uid: 33
     shell: /usr/sbin/nologin
+    # /var/www is the package maintainers default home for the www-data user,
+    # hence this is not set to php_fpm_www_dir
     home: /var/www
     groups:
       - www-data
@@ -49,13 +51,13 @@
       - "{{ php_fpm_pool_group | default(php_fpm_pool_name) }}"
       - www-data
     append: no
-    home: "/var/www/{{ php_fpm_pool_name }}"
+    home: "{{ php_fpm_www_dir }}/{{ php_fpm_pool_name }}"
   when: php_fpm_pool_user | default(php_fpm_pool_name) != 'www-data'
 
 - name: create chdir directory for php-fpm pool
   file:
     state: directory
-    path: "/var/www/{{ php_fpm_pool_name }}/{{ php_fpm_pool_chdir }}"
+    path: "{{ php_fpm_www_dir }}/{{ php_fpm_pool_name }}/{{ php_fpm_pool_chdir }}"
     owner: "{{ php_fpm_pool_user | default(php_fpm_pool_name) }}"
     group: "{{ php_fpm_pool_group | default(php_fpm_pool_name) }}"
     mode: 0750

--- a/tasks/configure/default.yml
+++ b/tasks/configure/default.yml
@@ -54,6 +54,11 @@
     home: "{{ php_fpm_www_dir }}/{{ php_fpm_pool_name }}"
   when: php_fpm_pool_user | default(php_fpm_pool_name) != 'www-data'
 
+- name: check if chdir is a symlink - in which case no need to create it
+  stat:
+    path: "{{ php_fpm_www_dir }}/{{ php_fpm_pool_name }}/{{ php_fpm_pool_chdir }}"
+  register: stat_php_fpm_chdir_symlink
+
 - name: create chdir directory for php-fpm pool
   file:
     state: directory
@@ -61,9 +66,7 @@
     owner: "{{ php_fpm_pool_user | default(php_fpm_pool_name) }}"
     group: "{{ php_fpm_pool_group | default(php_fpm_pool_name) }}"
     mode: 0750
-  when: php_fpm_pool_chdir is defined
-  # sometimes this is a symlink created by the deployment - in this case just skip it
-  ignore_errors: true
+  when: php_fpm_pool_chdir is defined and stat_php_fpm_chdir_symlink.stat.islnk is defined
 
 - name: create main tmpdir for all php-fpm pools of this php_version
   file:

--- a/tasks/configure/default.yml
+++ b/tasks/configure/default.yml
@@ -90,7 +90,7 @@
     src: tmpfs
     path: "/var/tmp/{{ php_fpm_pool_name }}"
     state: mounted
-    opts: "defaults,noexec,nosuid,size={{ php_fpm_pool_tmpdir_tmpfs_size }},uid={{ php_fpm_pool_uid_gid }},gid={{ php_fpm_pool_uid_gid }}"  # yamllint disable-line rule:line-length
+    opts: "defaults,noexec,nosuid,size={{ php_fpm_pool_tmpdir_tmpfs_size }},uid={{ php_fpm_pool_uid_gid }},gid={{ php_fpm_pool_uid_gid }},mode=0770"  # yamllint disable-line rule:line-length
   when: php_fpm_pool_tmpdir_tmpfs_size is defined
 
 - name: template custom php-fpm pool

--- a/templates/etc/php/all_versions/fpm/pool.d/pool.conf.j2
+++ b/templates/etc/php/all_versions/fpm/pool.d/pool.conf.j2
@@ -4,16 +4,16 @@
 user = {{ php_fpm_pool_user | default(php_fpm_pool_name) }}
 group = {{ php_fpm_pool_group | default(php_fpm_pool_name) }}
 {% if php_fpm_pool_chdir is defined %}
-chdir = {{ '/var/www/' + php_fpm_pool_name + '/' + php_fpm_pool_chdir }}
+chdir = {{ php_fpm_www_dir + '/' + php_fpm_pool_name + '/' + php_fpm_pool_chdir }}
 {% else %}
-chdir = {{ '/var/www/' + php_fpm_pool_name }}
+chdir = {{ php_fpm_www_dir + '/' + php_fpm_pool_name }}
 {% endif %}
 listen = /var/run/php/{{ php_fpm_pool_name }}.sock
 listen.owner = {{ php_fpm_pool_user | default(php_fpm_pool_name) }}
 listen.group = {{ php_fpm_pool_group | default(php_fpm_pool_name) }}
-env[TMP] = /var/www/tmp/{{ php_fpm_pool_name }}
-env[TMPDIR] = /var/www/tmp/{{ php_fpm_pool_name }}
-env[TEMP] = /var/www/tmp/{{ php_fpm_pool_name }}
+env[TMP] = {{ php_fpm_www_dir }}/tmp/{{ php_fpm_pool_name }}
+env[TMPDIR] = {{ php_fpm_www_dir }}/tmp/{{ php_fpm_pool_name }}
+env[TEMP] = {{ php_fpm_www_dir }}/tmp/{{ php_fpm_pool_name }}
 
 ; php-fpm worker mode settings
 pm = {{ php_fpm_pool_pm | default('static') }}

--- a/templates/etc/php/all_versions/fpm/pool.d/pool.conf.j2
+++ b/templates/etc/php/all_versions/fpm/pool.d/pool.conf.j2
@@ -3,7 +3,11 @@
 ; User / group and directory related settings
 user = {{ php_fpm_pool_user | default(php_fpm_pool_name) }}
 group = {{ php_fpm_pool_group | default(php_fpm_pool_name) }}
-chdir = {{ '/var/www/' + php_fpm_pool_name + '/' + php_fpm_pool_chdir | default('') ) }}
+{% if php_fpm_pool_chdir is defined %}
+chdir = {{ '/var/www/' + php_fpm_pool_name + '/' + php_fpm_pool_chdir }}
+{% else %}
+chdir = {{ '/var/www/' + php_fpm_pool_name }}
+{% endif %}
 listen = /var/run/php/{{ php_fpm_pool_name }}.sock
 listen.owner = {{ php_fpm_pool_user | default(php_fpm_pool_name) }}
 listen.group = {{ php_fpm_pool_group | default(php_fpm_pool_name) }}

--- a/templates/etc/php/all_versions/fpm/pool.d/pool.conf.j2
+++ b/templates/etc/php/all_versions/fpm/pool.d/pool.conf.j2
@@ -3,7 +3,7 @@
 ; User / group and directory related settings
 user = {{ php_fpm_pool_user | default(php_fpm_pool_name) }}
 group = {{ php_fpm_pool_group | default(php_fpm_pool_name) }}
-chdir = {{ php_fpm_chdir | default('/var/www/' + php_fpm_pool_name + '/htdocs') }}
+chdir = {{ '/var/www/' + php_fpm_pool_name + '/' + php_fpm_pool_chdir | default('') ) }}
 listen = /var/run/php/{{ php_fpm_pool_name }}.sock
 listen.owner = {{ php_fpm_pool_user | default(php_fpm_pool_name) }}
 listen.group = {{ php_fpm_pool_group | default(php_fpm_pool_name) }}


### PR DESCRIPTION
before if no php_fpm_pool_chdir was given it was defaulted to /htdocs (which is wrong entirely).

- there should be the possibility to just state no `php_fpm_pool_chdir` at all, which will result in `chdir = /var/www/{{ php_fpm_pool_name }}` (reference #20 and #17)
- if `php_fpm_pool_chdir` is given, it is correctly created by the formula - now it is also correctly templated in the role for the pool
- while we are at it, `/var/www` should be a variable in defaults/ that can be overridden in the play (I highly vote for having that standard for all customers so I think default/ is the best place for that, and "almost never" stating it in the play. (reference #19 )